### PR TITLE
RFC Form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
       Please provide a minimal code example that illustrates the basic idea behind your RFC.
       Reports with full repro code and descriptive detailed information will likely receive feedback faster.
 
-- type: textarea
+- type: input
   id: rfc-title
   attributes:
     label: RFC Title?

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,7 +38,7 @@ body:
 - type: textarea
   id: rfc-description
   attributes:
-    label: RFC Description?
+    label: Description
     description: |
       Here you go into more details about your proposal. This section can be few paragraphs long.
       

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -61,7 +61,7 @@ body:
 - type: textarea
   id: rfc-incompatibility
   attributes:
-    label: RFC Backward incompatibility?
+    label: Backwards Compatibility
     description: If your RFC introduces backward-incompatible changes, describe them and propose how to deal with them.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -53,7 +53,7 @@ body:
 - type: textarea
   id: rfc-code
   attributes:
-    label: RFC Code Examples?
+    label: Code Examples
     description: Code examples should be short and informative. Try to use real-world examples.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -31,7 +31,7 @@ body:
   id: rfc-motivation
   attributes:
     label: Motivation
-    description: Describe **why** you think this is a good idea. What problems does it solve?, Who can benefit from it?.
+    description: Describe **why** you think this is a good idea. What problems does it solve? Who can benefit from it?
   validations:
     required: false
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
 - type: textarea
   id: rfc-abstract
   attributes:
-    label: RFC Abstract?
+    label: Abstract
     description: Just a few sentences (less is more) where you describe your idea.
     placeholder: Your cool new idea for Nim.
   validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,7 +30,7 @@ body:
 - type: textarea
   id: rfc-motivation
   attributes:
-    label: RFC Motivation?
+    label: Motivation
     description: Describe **why** you think this is a good idea. What problems does it solve?, Who can benefit from it?.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,7 +44,7 @@ body:
       
       If you have an idea how to implement it, describe the steps needed.
       
-      If there were similar similar proposals already or there can be some alternative approaches to this problem, highlight the differences between those and your proposal, stating why your current proposal is superior.
+      If there are other similar proposals or alternative approaches, highlight the differences between those and your proposal, stating why your current proposal is superior.
       
       What are the downsides of this proposal?
   validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,74 @@
+name:        "RFC"
+description: "Create a new Request For Comments."
+labels:      ["unconfirmed"]
+body:
+
+- type: markdown
+  attributes:
+    value: |
+      Please provide a minimal code example that illustrates the basic idea behind your RFC.
+      Reports with full repro code and descriptive detailed information will likely receive feedback faster.
+
+- type: textarea
+  id: rfc-title
+  attributes:
+    label: RFC Title?
+    description: Use a short descriptive title
+    placeholder: RFC short title.
+  validations:
+    required: true
+
+- type: textarea
+  id: rfc-abstract
+  attributes:
+    label: RFC Abstract?
+    description: Just a few sentences (less is more) where you describe your idea.
+    placeholder: Your cool new idea for Nim.
+  validations:
+    required: true
+
+- type: textarea
+  id: rfc-motivation
+  attributes:
+    label: RFC Motivation?
+    description: Describe **why** you think this is a good idea. What problems does it solve?, Who can benefit from it?.
+  validations:
+    required: false
+
+- type: textarea
+  id: rfc-description
+  attributes:
+    label: RFC Description?
+    description: |
+      Here you go into more details about your proposal. This section can be few paragraphs long.
+      
+      If you have an idea how to implement it, describe the steps needed.
+      
+      If there were similar similar proposals already or there can be some alternative approaches to this problem, highlight the differences between those and your proposal, stating why your current proposal is superior.
+      
+      What are the downsides of this proposal?
+  validations:
+    required: true
+
+- type: textarea
+  id: rfc-code
+  attributes:
+    label: RFC Code Examples?
+    description: Code examples should be short and informative. Try to use real-world examples.
+  validations:
+    required: false
+
+- type: textarea
+  id: rfc-incompatibility
+  attributes:
+    label: RFC Backward incompatibility?
+    description: If your RFC introduces backward-incompatible changes, describe them and propose how to deal with them.
+  validations:
+    required: false
+
+- type: markdown
+  attributes:
+    value: |
+      - Thanks for your contributions!, your ideas will receive feedback from the community soon...
+      - **Remember to :star: Star the Nim project on GitHub!.**
+      - [Please, consider a Donation for the Nim project.](https://nim-lang.org/donate.html)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,7 +40,7 @@ body:
   attributes:
     label: Description
     description: |
-      Here you go into more details about your proposal. This section can be few paragraphs long.
+      Here, you go into more details about your proposal. This section can be a few paragraphs long.
       
       If you have an idea how to implement it, describe the steps needed.
       

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
 - type: input
   id: rfc-title
   attributes:
-    label: RFC Title?
+    label: Title
     description: Use a short descriptive title
     placeholder: RFC short title.
   validations:


### PR DESCRIPTION

![rfc-template](https://user-images.githubusercontent.com/1189414/167010264-98774ae1-55cf-4fad-b02c-c223a0d52a00.png "RFC Form")

I changed the existing template in the repo to a GitHub issue form, just 1 YAML.

https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema

Just improving the UX and making things easier for the users. 🙂
