### PR TITLE
Remove title from RFC form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,15 +9,6 @@ body:
       Please provide a minimal code example that illustrates the basic idea behind your RFC.
       Reports with full repro code and descriptive detailed information will likely receive feedback faster.
 
-- type: input
-  id: rfc-title
-  attributes:
-    label: Title
-    description: Use a short descriptive title
-    placeholder: RFC short title.
-  validations:
-    required: true
-
 - type: textarea
   id: rfc-abstract
   attributes:


### PR DESCRIPTION
Issues already have short titles, don't see the need for an even shorter title.